### PR TITLE
Made the jf_playlist_exporter script usable for my docker setup

### DIFF
--- a/jf_playlist_exporter.py
+++ b/jf_playlist_exporter.py
@@ -1,36 +1,36 @@
 import os
 import locale
+from glob import glob
 from xml.dom import minidom
 
 # Playlist directory.
-g_dir = "/var/lib/jellyfin/data/playlists"
-
+input_xml_playlist_directory = input("Input path to Jellyfin's XML playlist directory:")
+output_m3u8_playlist_directory = input("Input path to your output directory for the .m3u playlist files:")
 
 # There are subfolders in the playlist directory.
-for filename in os.listdir(g_dir):
-    g_subdir = os.path.join(g_dir, filename)
-    print(g_subdir)
+for playlist_name in os.listdir(input_xml_playlist_directory):
+    xml_playlist_subdir = os.path.join(input_xml_playlist_directory, playlist_name)
 
     # In the subfolders there are xml files
-    for xml_playlist in os.listdir(g_subdir):
-        g_fullpath = os.path.join(g_subdir, xml_playlist)
-        playlist_name = filename + '.m3u8'
-        f_path = os.path.join(g_dir,playlist_name)
-        print("Creating playlist")
-        #print(playlist_name)
+    for xml_playlist in glob(os.path.join(xml_playlist_subdir, "*.xml")):
+        xml_playlist_fullpath = os.path.join(xml_playlist_subdir, xml_playlist)
+        m3u8_playlist_name = playlist_name + '.m3u8'
+        m3u8_playlist_path = os.path.join(output_m3u8_playlist_directory, m3u8_playlist_name)
+        print("Creating playlist: " + playlist_name)
 
         # Start to write a file
-        with open(f_path, 'w') as writer:
+        with open(m3u8_playlist_path, 'w') as writer:
             writer.write("#EXTM3U")
             writer.write("\n")
 
             # Parse for each song in the playlist...
-            mydoc = minidom.parse(g_fullpath)
+            mydoc = minidom.parse(xml_playlist_fullpath)
             items = mydoc.getElementsByTagName('Path')
-        
+
             # add it to the file
             for elem in items:
-                writer.write(elem.firstChild.data.encode('utf8'))
+                writer.write(elem.firstChild.data)
                 writer.write("\n")
-        
+
 print("Done!")
+


### PR DESCRIPTION
Hi there, I ended up using your script to turn my jellyfin playlists into proper M3Us, but before I could do so I had to make some changes to make it work. Of course, you don't have to merge all my changes into your script, it's totally fine if you reject the PR and manually apply the changes you like the most. And so you don't get confused with the crazy diff (I changed at least a few variable names after all), here's a list of all the things I changed:

- Let the user choose an input and an output directory (I use docker on dietpi for jellyfin so your default path is incorrect on my raspberry pi)
- Used path globbing instead of iterating over all files in the playlist subdirectories, fixes #1
- removed `.encode('utf8')` when writing the paths into the m3u8 files because I got an error saying I can't write binary content into a file and this was the first workaround I found. If you know a better solution be sure to let me know
- Made variable names easier to understand (what the hell is a g_path? Why is the variable which stores the name of the playlist _subdirectories_ called _"filename”_ and not something like “playlist_name”?) 

I hope you find my contribution useful. Cheers